### PR TITLE
fix the error of illegal memory access caused by cub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             "cuda_rasterizer/backward.cu",
             "rasterize_points.cu",
             "ext.cpp"],
-            extra_compile_args={"nvcc": ["-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")]})
+            extra_compile_args={"nvcc": ["-Xcompiler", "-fno-gnu-unique","-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")]})
         ],
     cmdclass={
         'build_ext': BuildExtension


### PR DESCRIPTION
Fix an issue caused by cub.
From my own test, the problem happened when you call cub related functions, such as [InclusiveSum](https://nvlabs.github.io/cub/structcub_1_1_device_scan.html#a9416ac1ea26f9fde669d83ddc883795a) Here https://github.com/graphdeco-inria/diff-gaussian-rasterization/blob/main/cuda_rasterizer/rasterizer_impl.cu#L281.
The problem is that the copy process does not go all the way. From my test, the copy somehow stopped at around 80K. After I tried to bypass that function by using [std::inclusive_scan](https://en.cppreference.com/w/cpp/algorithm/inclusive_scan). However, illegal memory access happened somewhere in the backward pass. 
Afterward, I found that a similar issue kind of happened in custom-built Pytorch functions (https://github.com/NVIDIA/thrust/issues/1341) and found the solution here https://github.com/pytorch/pytorch/issues/52663#issuecomment-809092114.

After the test, I used the modified code to train [Gaussian Splatting](https://github.com/graphdeco-inria/gaussian-splatting) on the Blender Lego dataset, and it worked like a charm. 

Related issues:
- https://github.com/graphdeco-inria/gaussian-splatting/issues/23
- https://github.com/graphdeco-inria/gaussian-splatting/issues/41
Potentially related issue:
- https://github.com/graphdeco-inria/gaussian-splatting/issues/81
