### PR TITLE
NDC Space clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Used as the rasterization engine for the paper "3D Gaussian Splatting for Real-Time Rendering of Radiance Fields". If you can make use of it in your own research, please be so kind to cite us.
 
+## Main change of this repo
+Fix some bugs in the visible  frustum function and uses judgement criterion  using conventional NDC Space Culling  . 
+## TODO List
+  - integrate Detph and Alpha rendering
+
 <section class="section" id="BibTeX">
   <div class="container is-max-desktop content">
     <h2 class="title">BibTeX</h2>

--- a/cuda_rasterizer/auxiliary.h
+++ b/cuda_rasterizer/auxiliary.h
@@ -151,7 +151,8 @@ __forceinline__ __device__ bool in_frustum(int idx,
 	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
 	p_view = transformPoint4x3(p_orig, viewmatrix);
 
-	if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	// if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	if (p_proj.z < -1.01f||p_proj.z > 1.01f||p_proj.x>1.01f||p_proj.x<-1.01f||p_proj.y>1.01f||p_proj.y<-1.01f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
 	{
 		if (prefiltered)
 		{


### PR DESCRIPTION
Update Invisible Space Clipping function using Traditional NDC Clipping.
Original Clipping function  cuts space so naively  by z value when it is smaller than 0.2f in cam space coords. This will introduce some problems, especially when the scale of this scene is quite small( the scene with z being samller than 0.2 cannot be rendered normally. ).