### PR TITLE
Ensure all tensors in GaussianRasterizer's raster_settings are on the same device

### DIFF
--- a/diff_gaussian_rasterization/__init__.py
+++ b/diff_gaussian_rasterization/__init__.py
@@ -172,6 +172,15 @@ class GaussianRasterizer(nn.Module):
     def __init__(self, raster_settings):
         super().__init__()
         self.raster_settings = raster_settings
+        self._sanitizeSettings()
+    
+    def _sanitizeSettings(self):
+        # Check if all tensors in raster_settings is on same device
+        compute_devices = [_x.device for _x in self.raster_settings if isinstance(_x, torch.Tensor)]
+        if len(set(compute_devices)) > 1:
+            raise Exception('All tensors in raster_settings should be on the same device.')
+        if any([d == torch.device('cpu') for d in compute_devices]):
+            raise Exception('CUDA device is required for the rasterizer.')
 
     def markVisible(self, positions):
         # Mark visible points (based on frustum culling for camera) with a boolean 


### PR DESCRIPTION
When passing raster_settings to `GaussianRasterizationSettings`, beginners are very likely to forget to copy `.bg` and `.viewmatrix` to CUDA devices, leading to hard-to-debug `CUDA illegal memory access` issues. Therefore I believe a _sanitizeSettings should be added to throw a clear exception if the tensors are misplaced.

Here is a summary of this commit:

- Added _sanitizeSettings method in GaussianRasterizer class
- Check if all tensors in raster_settings are on the same device
- Raise an exception if tensors are on different devices
- Raise an exception if any tensor is on the CPU, requiring the use of a CUDA device