### PR TITLE
fix: Enable Multi-GPU Execution by Fixing Device Allocation Conflicts

### DIFF
--- a/rasterize_points.cu
+++ b/rasterize_points.cu
@@ -75,11 +75,10 @@ RasterizeGaussiansCUDA(
 
   torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
   
-  torch::Device device(torch::kCUDA);
-  torch::TensorOptions options(torch::kByte);
-  torch::Tensor geomBuffer = torch::empty({0}, options.device(device));
-  torch::Tensor binningBuffer = torch::empty({0}, options.device(device));
-  torch::Tensor imgBuffer = torch::empty({0}, options.device(device));
+  torch::TensorOptions byte_opts = means3D.options().dtype(torch::kByte);
+  torch::Tensor geomBuffer = torch::empty({0}, byte_opts);
+  torch::Tensor binningBuffer = torch::empty({0}, byte_opts);
+  torch::Tensor imgBuffer = torch::empty({0}, byte_opts);
   std::function<char*(size_t)> geomFunc = resizeFunctional(geomBuffer);
   std::function<char*(size_t)> binningFunc = resizeFunctional(binningBuffer);
   std::function<char*(size_t)> imgFunc = resizeFunctional(imgBuffer);


### PR DESCRIPTION
Thank you for building and maintaining this amazing project!

This PR fixes device mismatches in multi-GPU environments, e.g., move all the tensors of Gaussian model to `cuda:1` before run rendering.
The issue occurred when the three buffers were initialized on a default GPU (e.g. `cuda:0`) instead of matching the device of input tensors.